### PR TITLE
Add setup script for Codex Universal image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Expressive Resume and Cover Letter Template
+
+This repository contains a XeLaTeX template for generating an expressive resume (and related cover-letter assets).
+
+## Prerequisites
+
+The project depends on a TeX Live toolchain with XeLaTeX, Biber, and the EB Garamond/Garamond Math fonts that ship with `texlive-fonts-extra`.
+
+## Setup
+
+Run the provided setup script to install the required packages on Ubuntu-based environments (including the [Codex Universal](https://github.com/openai/codex-universal) image):
+
+```bash
+./setup.sh
+```
+
+## Building the resume
+
+After the dependencies are installed, compile the resume with `latexmk`:
+
+```bash
+cd src
+latexmk -xelatex -shell-escape resume.tex
+```
+
+The generated PDF will be placed in the `src/` directory.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine whether sudo is required.
+if [[ "${EUID}" -ne 0 ]]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+# Refresh package metadata and install dependencies needed to build the LaTeX resume.
+${SUDO} apt-get update
+${SUDO} apt-get install -y \
+  texlive-latex-base \
+  texlive-latex-extra \
+  texlive-fonts-extra \
+  texlive-bibtex-extra \
+  texlive-xetex \
+  latexmk \
+  biber
+
+# Print instructions for compiling the resume once dependencies are installed.
+cat <<'EOM'
+LaTeX toolchain installed.
+To compile the resume, run:
+  cd src
+  latexmk -xelatex -shell-escape resume.tex
+EOM


### PR DESCRIPTION
## Summary
- add a setup script that installs the LaTeX toolchain required to compile the resume when running on the Codex Universal image
- expand the README with setup prerequisites and build instructions for the template

## Testing
- bash -n setup.sh

------
https://chatgpt.com/codex/tasks/task_e_68ddc71c50b483338928cf4f7ec81683