### PR TITLE
Improve EB Garamond kerning and spacing for resume

### DIFF
--- a/src/Expressive.cls
+++ b/src/Expressive.cls
@@ -5,9 +5,20 @@
 \newcommand{\spacenormal}{0pt}
 
 
-\newcommand{\sectionfont}{\fontsize{21}{25.2}\selectfont} % Slightly bigger than normal
-\newcommand{\subsectionfont}{\fontsize{18}{21.6}\selectfont} % Slightly smaller than section
-\newcommand{\normaltextfont}{\fontsize{16.3}{19.56}\selectfont} % Base text
+\RequirePackage{fontspec}
+
+\newcommand{\sectionfont}{%
+  \fontsize{21}{25.2}\selectfont
+  \addfontfeatures{LetterSpace=3,Kerning=Uppercase,RawFeature={+kern}}
+} % Slightly bigger than normal
+\newcommand{\subsectionfont}{%
+  \fontsize{18}{21.6}\selectfont
+  \addfontfeatures{LetterSpace=1.5,Kerning=Uppercase,RawFeature={+kern}}
+} % Slightly smaller than section
+\newcommand{\normaltextfont}{%
+  \fontsize{16.3}{19.56}\selectfont
+  \addfontfeatures{RawFeature={+kern}}
+} % Base text
 
  % \AtBeginDocument{\normaltextfont}
 

--- a/src/ExpressiveResume.cls
+++ b/src/ExpressiveResume.cls
@@ -23,13 +23,15 @@
     qrcode
 ]{%
 \begin{center}
-    \fontsize{35}{42}\selectfont\textsc{\commandkey{firstname}\space\commandkey{lastname}}
+    {\fontsize{35}{42}\selectfont
+    \addfontfeatures{LetterSpace=6,Kerning=Uppercase,RawFeature={+kern}}\textsc{\commandkey{firstname}\space\commandkey{lastname}}}
     % \commandkey{firstname}%
     % \ifcommandkey{middleinitial}{\space\commandkey{middleinitial}.}{}%
     % \space\commandkey{lastname}%
     \\[5pt]
     \vspace{5pt}
-\fontsize{16}{19.2}\selectfont{
+{\fontsize{16}{19.2}\selectfont
+    \addfontfeatures{LetterSpace=1.2,RawFeature={+kern}}
     \ifcommandkey{state}{\location{\ifcommandkey{city}{\commandkey{city}, }{}\commandkey{state}}}{}%
     \ifcommandkey{phone}{\headersep\phone{\commandkey{phone}}}{}%
     \ifcommandkey{email}{\headersep\email{\commandkey{email}}}{}%

--- a/src/resume.tex
+++ b/src/resume.tex
@@ -26,17 +26,31 @@
 \usepackage{fontspec}
 \usepackage{unicode-math} % For modern, scalable math fonts
 
+% Consistent font defaults tuned for improved kerning and readability
+\defaultfontfeatures{
+  Ligatures = TeX,
+  Renderer  = HarfBuzz,
+  Scale     = MatchLowercase
+}
+
 % Use TeX Live's bundled EB Garamond fonts (hyphenated file names)
 \setmainfont{EBGaramond}[
-  Path             = /usr/local/texlive/2025/texmf-dist/fonts/opentype/public/ebgaramond/,
-  Extension        = .otf,
-  UprightFont      = *-Regular,
-  ItalicFont       = *-Italic,
-  BoldFont         = *-SemiBold,
-  BoldItalicFont   = *-SemiBoldItalic,
+  Path              = /usr/local/texlive/2025/texmf-dist/fonts/opentype/public/ebgaramond/,
+  Extension         = .otf,
+  UprightFont       = *-Regular,
+  ItalicFont        = *-Italic,
+  BoldFont          = *-SemiBold,
+  BoldItalicFont    = *-SemiBoldItalic,
   % Correctly define the semibold 'sb' series using FontFace
-  FontFace         = {sb}{n}{Font = *-SemiBold},
-  FontFace         = {sb}{it}{Font = *-SemiBoldItalic}
+  FontFace          = {sb}{n}{Font = *-SemiBold},
+  FontFace          = {sb}{it}{Font = *-SemiBoldItalic},
+  RawFeature        = {+kern,+liga},
+  Kerning           = Uppercase,
+  SmallCapsFeatures = {
+    LetterSpace = 5,
+    Kerning     = Uppercase,
+    RawFeature  = {+kern}
+  }
 ]
 
 % Set a readily available math font to avoid substitution warnings


### PR DESCRIPTION
## Summary
- enable HarfBuzz rendering and kerning-aware defaults for EB Garamond in the resume
- apply kerning and letter-spacing tweaks to heading and body font macros in the base class
- update the resume header typography to use the refined spacing for small caps contact details

## Testing
- not run (latexmk unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de4a6c3fec83338ffee9d79062a5c7