### PR TITLE
Improve small caps kerning for resume typography

### DIFF
--- a/src/resume.tex
+++ b/src/resume.tex
@@ -24,6 +24,7 @@
 
 % Use the fontspec package for modern font management
 \usepackage{fontspec}
+\defaultfontfeatures{Ligatures=TeX,Renderer=Harfbuzz,Scale=MatchLowercase}
 \usepackage{unicode-math} % For modern, scalable math fonts
 
 % Use TeX Live's bundled EB Garamond fonts (hyphenated file names)
@@ -34,6 +35,8 @@
   ItalicFont       = *-Italic,
   BoldFont         = *-SemiBold,
   BoldItalicFont   = *-SemiBoldItalic,
+  Ligatures        = TeX,
+  SmallCapsFeatures={LetterSpace=6},
   % Correctly define the semibold 'sb' series using FontFace
   FontFace         = {sb}{n}{Font = *-SemiBold},
   FontFace         = {sb}{it}{Font = *-SemiBoldItalic}


### PR DESCRIPTION
## Summary
- enable HarfBuzz rendering and TeX ligature support as default font features
- increase EB Garamond small caps letter spacing to improve kerning in headings and other small caps text

## Testing
- latexmk -xelatex resume.tex *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de4a6c3fec83338ffee9d79062a5c7