### PR TITLE
Improve font kerning and spacing

### DIFF
--- a/src/resume.tex
+++ b/src/resume.tex
@@ -25,6 +25,14 @@
 % Use the fontspec package for modern font management
 \usepackage{fontspec}
 \usepackage{unicode-math} % For modern, scalable math fonts
+\usepackage[tracking=true,kerning=true,spacing=true]{microtype}
+
+% Improve the default font shaping behaviour to emphasise kerning and spacing
+\defaultfontfeatures{Ligatures=TeX, Scale=MatchLowercase, Kerning=On}
+
+% Apply slightly more generous tracking to small caps text (used heavily in headings)
+\SetTracking{encoding={*}, shape=sc}{40}
+\SetTracking{encoding={*}, shape={scit}}{40}
 
 % Use TeX Live's bundled EB Garamond fonts (hyphenated file names)
 \setmainfont{EBGaramond}[


### PR DESCRIPTION
## Summary
- enable microtype to provide kerning, spacing, and tracking adjustments for EB Garamond
- tune default font features and small caps tracking to improve heading readability

## Testing
- `latexmk -xelatex resume.tex` *(fails: latexmk not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de4a6c3fec83338ffee9d79062a5c7